### PR TITLE
fix: ensure compatability with werkzeug 3.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    # manually triggered
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[testing]"
+      - name: Test with pytest
+        run: pytest

--- a/flask_loopback/flask_loopback.py
+++ b/flask_loopback/flask_loopback.py
@@ -53,7 +53,7 @@ class FlaskLoopback(object):
     def __init__(self, flask_app):
         super(FlaskLoopback, self).__init__()
         self.flask_app = flask_app
-        self._test_client = flask_app.test_client()
+        self._test_client = flask_app.test_client(use_cookies=False)
         self._request_context_handlers = []
         self._registered_addresses = set()
         self._use_ssl = {}
@@ -101,9 +101,6 @@ class FlaskLoopback(object):
                 except CustomHTTPResponse as e:
                     return e.response
 
-            self._test_client.cookie_jar.clear()
-            for cookie in request._cookies:  # pylint: disable=protected-access
-                self._test_client.cookie_jar.set_cookie(cookie)
             resp = self._test_client.open(path, **open_kwargs)
             returned = requests.Response()
             assert returned.url is None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 requests
 Flask
+six
 URLObject
+werkzeug>=1.0.0
 
 unittest2; python_version<'2.7'
 contextlib2; python_version<'3.3'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = Flask-Loopback
 classifiers =
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 summary = Library for faking HTTP requests using flask applications without actual network operations
 description-file =
     README.md


### PR DESCRIPTION
I have disabled the internal cookies that the test client uses. When use_cookies is True, it overrides the cookie header that is passed with open_kwargs to the open function, so after setting use_cookies to False, there is no need to change the cookies. This is tested with in `tests/test_cookies.py`.
I took the liberty of adding a github workflow and removing old versions from setup.cfg, let me know if this should be changed.