### PR TITLE
Add release job on tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on:
   push:
@@ -7,8 +7,7 @@ on:
     # manually triggered
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,48 @@
+name: Publish Python distribution to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-distribution:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    needs:
+    - build-distribution
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This workflow will create a distribution and upload it to pypi when a tag is pushed, this does not require setting up API keys in the repository, see more [here](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-package-distribution-releases-using-github-actions-ci-cd-workflows)
In order for this to work the project needs to be registered here https://pypi.org/manage/account/publishing/ with the following parameters:
![Screenshot 2024-08-15 at 10 57 26](https://github.com/user-attachments/assets/5b312d7b-de43-4557-8a24-e9564051a421)
@vmalloc Before merging this, can you try tagging this commit with a prerelease version to see that it indeed works, I have only tested it with [TestPyPI](https://test.pypi.org/project/Flask-Loopback/0.0.3/)
